### PR TITLE
Faster Packet Loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "rickybobby"
 	app.Usage = "Parsing DNS packets when you wanna GO fast!"
-	app.Version = "1.0.0"
+	app.Version = "1.0.1"
 	app.Compiled = time.Now()
 
 	app.Authors = []cli.Author{

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -111,6 +111,7 @@ PACKETLOOP:
 			continue
 		}
 
+		// Parse DNS and transport layer information
 		var msg *dns.Msg
 		transportLayer := packet.TransportLayer()
 		switch transportLayer.LayerType() {
@@ -152,12 +153,14 @@ PACKETLOOP:
 			schema.Sha256 = fmt.Sprintf("%x", sha256.Sum256(udp.Payload))
 		}
 
-		// This means we did not attempt to parse a DNS payload
+		// This means we did not attempt to parse a DNS payload and
+		// indicates an unexpected transport layer protocol
 		if msg == nil {
 			log.Debugf("No DNS packet found: %v\n", err)
 			continue PACKETLOOP
 		}
 
+		// Parse network layer information
 		networkLayer := packet.NetworkLayer()
 		switch networkLayer.LayerType() {
 		case layers.LayerTypeIPv4:
@@ -218,7 +221,7 @@ PACKETLOOP:
 			schema.Qtype = qr.Qtype
 		}
 
-		// Let's get QUESTION information on if:
+		// Let's get QUESTION information if:
 		//   1. Questions flag is set
 		//   2. QuestionsEcs flag is set and ECS information in question
 		//   3. NXDOMAINs without RRs (i.e., SOA)

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -156,7 +156,7 @@ PACKETLOOP:
 		// This means we did not attempt to parse a DNS payload and
 		// indicates an unexpected transport layer protocol
 		if msg == nil {
-			log.Debugf("No DNS packet found: %v\n", err)
+			log.Debug("Unexpected transport layer protocol")
 			continue PACKETLOOP
 		}
 

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -99,12 +99,13 @@ func ParseDns(handle *pcap.Handle) {
 
 PACKETLOOP:
 	for {
-		stats.PacketTotal += 1
-
 		packet, err := packetSource.NextPacket()
 		if err == io.EOF {
 			break
-		} else if err != nil {
+		}
+		stats.PacketTotal += 1
+
+		if err != nil {
 			log.Errorf("Error decoding some part of the packet: %v\n", err)
 			stats.PacketErrors += 1
 			continue

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -86,6 +86,7 @@ func ParseDns(handle *pcap.Handle) {
 		ip6    *layers.IPv6
 		tcp    *layers.TCP
 		udp    *layers.UDP
+		msg    *dns.Msg
 	)
 
 	// Set the source and sensor for packet source
@@ -112,7 +113,7 @@ PACKETLOOP:
 		}
 
 		// Parse DNS and transport layer information
-		var msg *dns.Msg
+		msg = nil
 		transportLayer := packet.TransportLayer()
 		switch transportLayer.LayerType() {
 		case layers.LayerTypeTCP:


### PR DESCRIPTION
Add performance improvements to the packet parsing loop via the following changes:

1. Add BPF filtering for PCAP files
2. Switch to non-channel based loop using `packet.NextPacket()`
3. Turn on `LazyDecode` to prevent parsing application layer data twice

These changes seem to have resulted in a roughly 15-20% improvement in performance over the latest version.